### PR TITLE
Add NAS search framework with multiple algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # nas-optimization-suite
+
+This repository provides a simple neural architecture search (NAS) framework
+that explores CNN and Transformer blocks for image classification. It includes
+implementations of several optimization strategies from scratch:
+
+- Particle Swarm Optimization (PSO)
+- Genetic Algorithm (GA)
+- Tree-structured Parzen Estimator (TPE)
+- CMA-ES
+- DARTS
+- REINFORCE
+
+The search space is defined as a sequence of block IDs where each block can be a
+convolutional block, transformer block, or pooling block. Models are built using
+PyTorch and trained on an image classification dataset for a few epochs with
+simple early stopping.
+
+A small fallback dataset (CIFAR-100) is used when the ImageNet16-120 subset is
+not available. This keeps the example lightweight so the search procedures can
+run in constrained environments. The training routine is short (5 epochs) and
+intended for demonstration rather than high accuracy.
+
+Run the search with:
+
+```bash
+python main.py
+```
+
+Each algorithm prints the best architecture it discovered along with the
+validation accuracy obtained during the search.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+import torch
+from nas_framework.dataset import get_dataloaders
+from nas_framework.search import pso, ga, tpe, cmaes, darts, reinforce
+
+
+def main():
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    train_loader, val_loader, test_loader = get_dataloaders()
+    results = {}
+
+    arch, score = pso.pso_search(train_loader, val_loader, device)
+    results['PSO'] = (arch, score)
+
+    arch, score = ga.ga_search(train_loader, val_loader, device)
+    results['GA'] = (arch, score)
+
+    arch, score = tpe.tpe_search(train_loader, val_loader, device)
+    results['TPE'] = (arch, score)
+
+    arch, score = cmaes.cma_es_search(train_loader, val_loader, device)
+    results['CMA-ES'] = (arch, score)
+
+    arch, score = darts.darts_search(train_loader, val_loader, device)
+    results['DARTS'] = (arch, score)
+
+    arch, score = reinforce.reinforce_search(train_loader, val_loader, device)
+    results['REINFORCE'] = (arch, score)
+
+    for method, (arch, score) in results.items():
+        print(f'{method}: best_arch={arch} score={score:.4f}')
+
+
+if __name__ == '__main__':
+    main()

--- a/nas_framework/__init__.py
+++ b/nas_framework/__init__.py
@@ -1,0 +1,6 @@
+from .model import build_model
+from .dataset import get_dataloaders
+from .train_eval import train_and_eval
+from . import search
+
+__all__ = ['build_model', 'get_dataloaders', 'train_and_eval', 'search']

--- a/nas_framework/dataset.py
+++ b/nas_framework/dataset.py
@@ -1,0 +1,23 @@
+import torchvision
+from torchvision import transforms
+from torch.utils.data import DataLoader, random_split
+
+def get_dataloaders(batch_size=32):
+    transform = transforms.Compose([
+        transforms.Resize(32),
+        transforms.ToTensor(),
+    ])
+    try:
+        dataset = torchvision.datasets.ImageFolder('data/imagenet16-120/train', transform=transform)
+        val_dataset = torchvision.datasets.ImageFolder('data/imagenet16-120/val', transform=transform)
+    except Exception:
+        # Fallback to CIFAR100 if ImageNet subset is unavailable
+        dataset = torchvision.datasets.CIFAR100(root='data', train=True, download=True, transform=transform)
+        val_dataset = torchvision.datasets.CIFAR100(root='data', train=False, download=True, transform=transform)
+    val_size = int(0.1 * len(dataset))
+    train_size = len(dataset) - val_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=2)
+    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False, num_workers=2)
+    test_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2)
+    return train_loader, val_loader, test_loader

--- a/nas_framework/model.py
+++ b/nas_framework/model.py
@@ -1,0 +1,59 @@
+import torch
+import torch.nn as nn
+from typing import List
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int = 64, kernel_size: int = 3):
+        super().__init__()
+        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, padding=kernel_size//2)
+        self.bn = nn.BatchNorm2d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        return self.relu(self.bn(self.conv(x)))
+
+class TransformerBlock(nn.Module):
+    def __init__(self, dim: int, num_heads: int = 4):
+        super().__init__()
+        encoder_layer = nn.TransformerEncoderLayer(dim, num_heads)
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=1)
+
+    def forward(self, x):
+        b, c, h, w = x.shape
+        x = x.flatten(2).permute(2, 0, 1)  # (HW, B, C)
+        x = self.transformer(x)
+        x = x.permute(1, 2, 0).view(b, c, h, w)
+        return x
+
+class PoolBlock(nn.Module):
+    def __init__(self, mode: str = 'max'):
+        super().__init__()
+        if mode == 'avg':
+            self.pool = nn.AvgPool2d(2)
+        else:
+            self.pool = nn.MaxPool2d(2)
+
+    def forward(self, x):
+        return self.pool(x)
+
+BLOCK_TYPES = {
+    0: ConvBlock,
+    1: TransformerBlock,
+    2: PoolBlock,
+}
+
+def build_model(block_ids: List[int], in_channels: int = 3, num_classes: int = 100):
+    layers = []
+    channels = in_channels
+    for bid in block_ids:
+        if bid == 0:
+            layers.append(ConvBlock(channels))
+        elif bid == 1:
+            layers.append(TransformerBlock(channels))
+        elif bid == 2:
+            layers.append(PoolBlock())
+        channels = 64  # keep constant for simplicity
+    layers.append(nn.AdaptiveAvgPool2d(1))
+    layers.append(nn.Flatten())
+    layers.append(nn.Linear(channels, num_classes))
+    return nn.Sequential(*layers)

--- a/nas_framework/search/__init__.py
+++ b/nas_framework/search/__init__.py
@@ -1,0 +1,2 @@
+from . import pso, ga, tpe, cmaes, darts, reinforce
+__all__ = ['pso', 'ga', 'tpe', 'cmaes', 'darts', 'reinforce']

--- a/nas_framework/search/cmaes.py
+++ b/nas_framework/search/cmaes.py
@@ -1,0 +1,22 @@
+import numpy as np
+from ..utils import BLOCK_CHOICES
+from ..train_eval import train_and_eval
+
+
+def cma_es_search(train_loader, val_loader, device, num_blocks=3, iterations=3):
+    mean = np.zeros(num_blocks)
+    sigma = 1.0
+    best_arch = None
+    best_score = 0
+    for _ in range(iterations):
+        samples = np.random.randn(4, num_blocks) * sigma + mean
+        samples = np.clip(samples, 0, len(BLOCK_CHOICES)-1)
+        for s in samples:
+            arch = [BLOCK_CHOICES[int(round(v))] for v in s]
+            score, _ = train_and_eval(arch, train_loader, val_loader, device)
+            if score > best_score:
+                best_score = score
+                best_arch = arch
+        mean = samples.mean(axis=0)
+        sigma *= 0.9
+    return best_arch, best_score

--- a/nas_framework/search/darts.py
+++ b/nas_framework/search/darts.py
@@ -1,0 +1,46 @@
+import torch
+import torch.nn as nn
+from ..model import ConvBlock, TransformerBlock, PoolBlock
+from ..train_eval import train_one_epoch, evaluate
+
+class DARTSCell(nn.Module):
+    def __init__(self, in_channels):
+        super().__init__()
+        self.ops = nn.ModuleList([
+            ConvBlock(in_channels),
+            TransformerBlock(in_channels),
+            PoolBlock()
+        ])
+        self.alpha = nn.Parameter(torch.zeros(len(self.ops)))
+
+    def forward(self, x):
+        weights = torch.softmax(self.alpha, dim=0)
+        return sum(w * op(x) for w, op in zip(weights, self.ops))
+
+class DARTSNetwork(nn.Module):
+    def __init__(self, num_blocks=3, in_channels=3, num_classes=100):
+        super().__init__()
+        self.cells = nn.ModuleList([DARTSCell(in_channels if i==0 else 64) for i in range(num_blocks)])
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Linear(64, num_classes)
+
+    def forward(self, x):
+        for cell in self.cells:
+            x = cell(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        return self.fc(x)
+
+
+def darts_search(train_loader, val_loader, device, num_blocks=3, epochs=5):
+    model = DARTSNetwork(num_blocks=num_blocks).to(device)
+    optimizer = torch.optim.Adam(model.parameters())
+    criterion = nn.CrossEntropyLoss()
+    best_acc = 0
+    for epoch in range(epochs):
+        train_one_epoch(model, train_loader, criterion, optimizer, device)
+        acc = evaluate(model, val_loader, device)
+        if acc > best_acc:
+            best_acc = acc
+    arch = [cell.alpha.argmax().item() for cell in model.cells]
+    return arch, best_acc

--- a/nas_framework/search/ga.py
+++ b/nas_framework/search/ga.py
@@ -1,0 +1,25 @@
+import random
+from ..utils import random_arch, mutate_arch
+from ..train_eval import train_and_eval
+
+
+def crossover(a, b):
+    point = random.randint(1, len(a)-1)
+    return a[:point] + b[point:]
+
+
+def ga_search(train_loader, val_loader, device, pop_size=4, generations=3):
+    population = [random_arch() for _ in range(pop_size)]
+    scores = [0] * pop_size
+    for g in range(generations):
+        for i, arch in enumerate(population):
+            scores[i], _ = train_and_eval(arch, train_loader, val_loader, device)
+        ranked = sorted(zip(scores, population), key=lambda x: x[0], reverse=True)
+        population = [ranked[0][1], ranked[1][1]]
+        while len(population) < pop_size:
+            parent1, parent2 = random.sample(ranked[:2], 2)
+            child = crossover(parent1[1], parent2[1])
+            child = mutate_arch(child)
+            population.append(child)
+    best_score, best_arch = max(zip(scores, population), key=lambda x: x[0])
+    return best_arch, best_score

--- a/nas_framework/search/pso.py
+++ b/nas_framework/search/pso.py
@@ -1,0 +1,36 @@
+import random
+from typing import List
+
+from ..train_eval import train_and_eval
+from ..utils import random_arch, BLOCK_CHOICES
+
+class Particle:
+    def __init__(self, position: List[int]):
+        self.position = position
+        self.best_position = position[:]
+        self.velocity = [0] * len(position)
+        self.best_score = 0
+
+
+def pso_search(train_loader, val_loader, device, num_particles=3, iterations=3):
+    particles = [Particle(random_arch()) for _ in range(num_particles)]
+    global_best = particles[0].position
+    global_best_score = 0
+
+    for _ in range(iterations):
+        for p in particles:
+            score, _ = train_and_eval(p.position, train_loader, val_loader, device)
+            if score > p.best_score:
+                p.best_score = score
+                p.best_position = p.position[:]
+            if score > global_best_score:
+                global_best_score = score
+                global_best = p.position[:]
+        for p in particles:
+            for i in range(len(p.position)):
+                vel = random.random() * (p.best_position[i] - p.position[i]) + \
+                      random.random() * (BLOCK_CHOICES.index(global_best[i]) - BLOCK_CHOICES.index(p.position[i]))
+                p.velocity[i] = vel
+                new_val = BLOCK_CHOICES[(BLOCK_CHOICES.index(p.position[i]) + int(round(vel))) % len(BLOCK_CHOICES)]
+                p.position[i] = new_val
+    return global_best, global_best_score

--- a/nas_framework/search/reinforce.py
+++ b/nas_framework/search/reinforce.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn as nn
+from ..utils import BLOCK_CHOICES
+from ..train_eval import train_and_eval
+
+class Policy(nn.Module):
+    def __init__(self, num_blocks=3, num_ops=3):
+        super().__init__()
+        self.logits = nn.Parameter(torch.zeros(num_blocks, num_ops))
+
+    def sample(self):
+        probs = torch.softmax(self.logits, dim=1)
+        m = torch.distributions.Categorical(probs)
+        actions = m.sample()
+        log_probs = m.log_prob(actions)
+        return actions.tolist(), log_probs.sum()
+
+
+def reinforce_search(train_loader, val_loader, device, num_blocks=3, episodes=5, lr=0.1):
+    policy = Policy(num_blocks, len(BLOCK_CHOICES)).to(device)
+    optimizer = torch.optim.Adam(policy.parameters(), lr=lr)
+    best_arch = None
+    best_score = 0
+    for _ in range(episodes):
+        arch, log_prob = policy.sample()
+        arch = [BLOCK_CHOICES[a] for a in arch]
+        score, _ = train_and_eval(arch, train_loader, val_loader, device)
+        loss = -log_prob * score
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if score > best_score:
+            best_score = score
+            best_arch = arch
+    return best_arch, best_score

--- a/nas_framework/search/tpe.py
+++ b/nas_framework/search/tpe.py
@@ -1,0 +1,33 @@
+import random
+from collections import defaultdict
+from ..utils import random_arch, BLOCK_CHOICES
+from ..train_eval import train_and_eval
+
+
+def tpe_search(train_loader, val_loader, device, trials=5):
+    observations = []
+    for _ in range(trials):
+        if len(observations) < 2:
+            arch = random_arch()
+        else:
+            good = [a for a, s in observations if s > 0.5 * max([sc for _, sc in observations])]
+            probs = defaultdict(int)
+            for a in good:
+                for i, b in enumerate(a):
+                    probs[(i, b)] += 1
+            arch = []
+            for i in range(len(good[0])):
+                choices = [c for c in BLOCK_CHOICES]
+                weights = [probs.get((i, c), 1) for c in choices]
+                total = sum(weights)
+                r = random.random() * total
+                cum = 0
+                for c, w in zip(choices, weights):
+                    cum += w
+                    if r <= cum:
+                        arch.append(c)
+                        break
+        score, _ = train_and_eval(arch, train_loader, val_loader, device)
+        observations.append((arch, score))
+    best_arch, best_score = max(observations, key=lambda x: x[1])
+    return best_arch, best_score

--- a/nas_framework/train_eval.py
+++ b/nas_framework/train_eval.py
@@ -1,0 +1,51 @@
+import time
+import torch
+import torch.nn as nn
+from .model import build_model
+
+
+def train_one_epoch(model, loader, criterion, optimizer, device):
+    model.train()
+    total_loss = 0
+    for data, target in loader:
+        data, target = data.to(device), target.to(device)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = criterion(output, target)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item() * data.size(0)
+    return total_loss / len(loader.dataset)
+
+
+def evaluate(model, loader, device):
+    model.eval()
+    correct = 0
+    with torch.no_grad():
+        for data, target in loader:
+            data, target = data.to(device), target.to(device)
+            output = model(data)
+            pred = output.argmax(dim=1)
+            correct += (pred == target).sum().item()
+    return correct / len(loader.dataset)
+
+
+def train_and_eval(block_ids, train_loader, val_loader, device, epochs=5, patience=2):
+    model = build_model(block_ids).to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters())
+    best_acc = 0
+    epochs_no_improve = 0
+    start = time.time()
+    for epoch in range(epochs):
+        train_one_epoch(model, train_loader, criterion, optimizer, device)
+        acc = evaluate(model, val_loader, device)
+        if acc > best_acc:
+            best_acc = acc
+            epochs_no_improve = 0
+        else:
+            epochs_no_improve += 1
+            if epochs_no_improve >= patience:
+                break
+    runtime = time.time() - start
+    return best_acc, runtime

--- a/nas_framework/utils.py
+++ b/nas_framework/utils.py
@@ -1,0 +1,15 @@
+import random
+
+BLOCK_CHOICES = [0, 1, 2]  # Conv, Transformer, Pool
+
+
+def random_arch(num_blocks=3):
+    return [random.choice(BLOCK_CHOICES) for _ in range(num_blocks)]
+
+
+def mutate_arch(arch, mutation_rate=0.1):
+    new_arch = arch[:]
+    for i in range(len(new_arch)):
+        if random.random() < mutation_rate:
+            new_arch[i] = random.choice(BLOCK_CHOICES)
+    return new_arch


### PR DESCRIPTION
## Summary
- add a simple NAS framework with CNN and Transformer blocks
- support several search strategies: PSO, GA, TPE, CMA-ES, DARTS, and REINFORCE
- implement basic training loop with early stopping on CIFAR-100 fallback
- provide main script to run all searches

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install torch==2.0.1+cpu torchvision==0.15.2+cpu -f https://download.pytorch.org/whl/torch_stable.html --quiet` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_685683e2d064832297b7e055c694c7cb